### PR TITLE
Add multi-platform NetEase sensitive word checking plugin

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.remiaft</groupId>
+        <artifactId>NeteaseWordsCheck</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neteasewordscheck-bukkit</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.remiaft</groupId>
+            <artifactId>neteasewordscheck-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.json</pattern>
+                                    <shadedPattern>com.remiaft.neteasewordscheck.shaded.json</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/bukkit/src/main/java/com/remiaft/neteasewordscheck/bukkit/NeteaseWordsCheckBukkitPlugin.java
+++ b/bukkit/src/main/java/com/remiaft/neteasewordscheck/bukkit/NeteaseWordsCheckBukkitPlugin.java
@@ -1,0 +1,133 @@
+package com.remiaft.neteasewordscheck.bukkit;
+
+import com.remiaft.neteasewordscheck.config.PluginConfiguration;
+import com.remiaft.neteasewordscheck.service.CheckResult;
+import com.remiaft.neteasewordscheck.service.NeteaseWordsCheckCore;
+import com.remiaft.neteasewordscheck.service.WordCheckService;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+
+public final class NeteaseWordsCheckBukkitPlugin extends JavaPlugin implements Listener {
+    private static final long CHECK_TIMEOUT_SECONDS = 5L;
+
+    private NeteaseWordsCheckCore core;
+    private PluginConfiguration configuration;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        reloadComponent();
+        Bukkit.getPluginManager().registerEvents(this, this);
+        getLogger().info("NeteaseWordsCheck enabled successfully.");
+    }
+
+    @Override
+    public void onDisable() {
+        if (core != null) {
+            core.close();
+            core = null;
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onAsyncPlayerChat(AsyncPlayerChatEvent event) {
+        if (core == null) {
+            return;
+        }
+        WordCheckService service = core.getWordCheckService();
+        try {
+            CheckResult result = service.checkAsync(event.getMessage()).get(CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!result.isAllowed() && configuration.isBlockOnViolation()) {
+                event.setCancelled(true);
+                String details = result.getViolationDetails().orElse("未知违规内容");
+                runSync(() -> event.getPlayer().sendMessage("§c消息包含敏感词：" + details));
+            }
+        } catch (Exception exception) {
+            getLogger().log(Level.WARNING, "Failed to check message with NetEase API", exception);
+        }
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!"neteasecheck".equalsIgnoreCase(command.getName())) {
+            return false;
+        }
+        if (args.length == 0) {
+            sender.sendMessage("§e用法: /neteasecheck <内容>");
+            return true;
+        }
+        if (core == null) {
+            sender.sendMessage("§c插件尚未完全初始化。");
+            return true;
+        }
+        String message = String.join(" ", args);
+        sender.sendMessage("§7正在检查消息，请稍候...");
+        core.getWordCheckService().checkAsync(message).whenComplete((result, throwable) -> {
+            if (throwable != null) {
+                getLogger().log(Level.WARNING, "Failed to check message", throwable);
+                runSync(() -> sender.sendMessage("§c检查失败，请查看后台日志。"));
+                return;
+            }
+            if (result.isAllowed()) {
+                runSync(() -> sender.sendMessage("§a未检测到敏感词。"));
+            } else {
+                runSync(() -> sender.sendMessage("§c检测到敏感词：" + result.getViolationDetails().orElse("未知")));
+            }
+        });
+        return true;
+    }
+
+    private void runSync(Runnable runnable) {
+        try {
+            Method method = Bukkit.getServer().getClass().getMethod("getGlobalRegionScheduler");
+            Object scheduler = method.invoke(Bukkit.getServer());
+            Method execute = scheduler.getClass().getMethod("execute", JavaPlugin.class, Consumer.class);
+            Consumer<Object> taskConsumer = task -> runnable.run();
+            execute.invoke(scheduler, this, taskConsumer);
+        } catch (Exception ignored) {
+            Bukkit.getScheduler().runTask(this, runnable);
+        }
+    }
+
+    private void reloadComponent() {
+        FileConfiguration config = getConfig();
+        Properties properties = toProperties(config);
+        configuration = PluginConfiguration.fromProperties(properties);
+        if (core != null) {
+            core.close();
+        }
+        try {
+            Path dataPath = new File(getDataFolder(), "data").toPath();
+            core = new NeteaseWordsCheckCore(dataPath, configuration, getLogger());
+        } catch (IOException exception) {
+            getLogger().log(Level.SEVERE, "Unable to initialize cache storage", exception);
+        }
+    }
+
+    private Properties toProperties(FileConfiguration configuration) {
+        Properties properties = new Properties();
+        configuration.getKeys(true).forEach(key -> {
+            Object value = configuration.get(key);
+            if (value != null) {
+                properties.put(key, String.valueOf(value));
+            }
+        });
+        return properties;
+    }
+}

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -1,0 +1,13 @@
+cache:
+  mode: H2
+  ttl-minutes: 60
+chat:
+  block-on-violation: true
+mysql:
+  host: localhost
+  port: 3306
+  database: netease_words
+  username: root
+  password: ""
+  use-ssl: false
+worker-threads: 4

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -1,0 +1,9 @@
+name: NeteaseWordsCheck
+main: com.remiaft.neteasewordscheck.bukkit.NeteaseWordsCheckBukkitPlugin
+version: ${project.version}
+author: Angelhell
+api-version: 1.13
+commands:
+  neteasecheck:
+    description: 检查一段文本是否包含敏感词
+    usage: /neteasecheck <内容>

--- a/bungeecord/pom.xml
+++ b/bungeecord/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.remiaft</groupId>
+        <artifactId>NeteaseWordsCheck</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neteasewordscheck-bungeecord</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.remiaft</groupId>
+            <artifactId>neteasewordscheck-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-api</artifactId>
+            <version>1.21-R0.4</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.json</pattern>
+                                    <shadedPattern>com.remiaft.neteasewordscheck.shaded.json</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/bungeecord/src/main/java/com/remiaft/neteasewordscheck/bungee/NeteaseWordsCheckBungeePlugin.java
+++ b/bungeecord/src/main/java/com/remiaft/neteasewordscheck/bungee/NeteaseWordsCheckBungeePlugin.java
@@ -1,0 +1,159 @@
+package com.remiaft.neteasewordscheck.bungee;
+
+import com.remiaft.neteasewordscheck.config.PluginConfiguration;
+import com.remiaft.neteasewordscheck.service.CheckResult;
+import com.remiaft.neteasewordscheck.service.NeteaseWordsCheckCore;
+import com.remiaft.neteasewordscheck.service.WordCheckService;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.ChatEvent;
+import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.event.EventHandler;
+import net.md_5.bungee.config.Configuration;
+import net.md_5.bungee.config.ConfigurationProvider;
+import net.md_5.bungee.config.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+public final class NeteaseWordsCheckBungeePlugin extends Plugin implements Listener {
+    private static final long CHECK_TIMEOUT_SECONDS = 5L;
+
+    private NeteaseWordsCheckCore core;
+    private PluginConfiguration configuration;
+
+    @Override
+    public void onEnable() {
+        try {
+            saveDefaultConfig();
+        } catch (IOException exception) {
+            getLogger().log(Level.SEVERE, "Unable to save default configuration", exception);
+        }
+        reloadComponent();
+        getProxy().getPluginManager().registerListener(this, this);
+        getProxy().getPluginManager().registerCommand(this, new NeteaseCheckCommand());
+        getLogger().info("NeteaseWordsCheck Bungee module enabled.");
+    }
+
+    @Override
+    public void onDisable() {
+        if (core != null) {
+            core.close();
+            core = null;
+        }
+    }
+
+    @EventHandler
+    public void onChat(ChatEvent event) {
+        if (core == null || event.isCommand()) {
+            return;
+        }
+        if (!(event.getSender() instanceof ProxiedPlayer player)) {
+            return;
+        }
+        WordCheckService service = core.getWordCheckService();
+        try {
+            CheckResult result = service.checkAsync(event.getMessage()).get(CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!result.isAllowed() && configuration.isBlockOnViolation()) {
+                event.setCancelled(true);
+                String details = result.getViolationDetails().orElse("未知违规内容");
+                player.sendMessage(ChatMessageType.CHAT, new TextComponent("§c消息包含敏感词：" + details));
+            }
+        } catch (Exception exception) {
+            getLogger().log(Level.WARNING, "Failed to check chat message", exception);
+        }
+    }
+
+    private void reloadComponent() {
+        try {
+            Properties properties = loadProperties();
+            configuration = PluginConfiguration.fromProperties(properties);
+            if (core != null) {
+                core.close();
+            }
+            Path dataPath = new File(getDataFolder(), "data").toPath();
+            core = new NeteaseWordsCheckCore(dataPath, configuration, getLogger());
+        } catch (Exception exception) {
+            getLogger().log(Level.SEVERE, "Failed to initialize NeteaseWordsCheck", exception);
+        }
+    }
+
+    private Properties loadProperties() throws IOException {
+        File configFile = new File(getDataFolder(), "config.yml");
+        Configuration configuration = ConfigurationProvider.getProvider(YamlConfiguration.class).load(configFile);
+        Properties properties = new Properties();
+        populateProperties(configuration, properties, "");
+        return properties;
+    }
+
+    private void populateProperties(Configuration source, Properties properties, String prefix) {
+        Collection<String> keys = source.getKeys();
+        for (String key : keys) {
+            String fullKey = prefix.isEmpty() ? key : prefix + "." + key;
+            Object value = source.get(key);
+            if (value instanceof Configuration section) {
+                populateProperties(section, properties, fullKey);
+            } else if (value != null) {
+                properties.put(fullKey, String.valueOf(value));
+            }
+        }
+    }
+
+    private void saveDefaultConfig() throws IOException {
+        if (!getDataFolder().exists()) {
+            getDataFolder().mkdirs();
+        }
+        File configFile = new File(getDataFolder(), "config.yml");
+        if (!configFile.exists()) {
+            try (InputStream in = getResourceAsStream("config.yml")) {
+                if (in == null) {
+                    throw new IOException("Default configuration not found");
+                }
+                Files.copy(in, configFile.toPath());
+            }
+        }
+    }
+
+    private final class NeteaseCheckCommand extends Command {
+        private NeteaseCheckCommand() {
+            super("neteasecheck", null, "nwc");
+        }
+
+        @Override
+        public void execute(CommandSender sender, String[] args) {
+            if (core == null) {
+                sender.sendMessage(new TextComponent("§c插件尚未准备就绪。"));
+                return;
+            }
+            if (args.length == 0) {
+                sender.sendMessage(new TextComponent("§e用法: /neteasecheck <内容>"));
+                return;
+            }
+            String message = String.join(" ", args);
+            sender.sendMessage(new TextComponent("§7正在检查消息，请稍候..."));
+            core.getWordCheckService().checkAsync(message).whenComplete((result, throwable) -> {
+                if (throwable != null) {
+                    getLogger().log(Level.WARNING, "Failed to check message", throwable);
+                    sender.sendMessage(new TextComponent("§c检查失败，请查看后台日志。"));
+                    return;
+                }
+                if (result.isAllowed()) {
+                    sender.sendMessage(new TextComponent("§a未检测到敏感词。"));
+                } else {
+                    sender.sendMessage(new TextComponent("§c检测到敏感词：" + result.getViolationDetails().orElse("未知")));
+                }
+            });
+        }
+    }
+}

--- a/bungeecord/src/main/resources/bungee.yml
+++ b/bungeecord/src/main/resources/bungee.yml
@@ -1,0 +1,4 @@
+name: NeteaseWordsCheck
+main: com.remiaft.neteasewordscheck.bungee.NeteaseWordsCheckBungeePlugin
+version: ${project.version}
+author: Angelhell

--- a/bungeecord/src/main/resources/config.yml
+++ b/bungeecord/src/main/resources/config.yml
@@ -1,0 +1,13 @@
+cache:
+  mode: H2
+  ttl-minutes: 60
+chat:
+  block-on-violation: true
+mysql:
+  host: localhost
+  port: 3306
+  database: netease_words
+  username: root
+  password: ""
+  use-ssl: false
+worker-threads: 4

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.remiaft</groupId>
+        <artifactId>NeteaseWordsCheck</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neteasewordscheck-common</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/common/src/main/java/com/remiaft/neteasewordscheck/cache/CacheEntry.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/cache/CacheEntry.java
@@ -1,0 +1,28 @@
+package com.remiaft.neteasewordscheck.cache;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public final class CacheEntry {
+    private final String content;
+    private final String violation;
+    private final Instant checkedAt;
+
+    public CacheEntry(String content, String violation, Instant checkedAt) {
+        this.content = Objects.requireNonNull(content, "content");
+        this.violation = violation;
+        this.checkedAt = Objects.requireNonNull(checkedAt, "checkedAt");
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getViolation() {
+        return violation;
+    }
+
+    public Instant getCheckedAt() {
+        return checkedAt;
+    }
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/cache/CacheProvider.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/cache/CacheProvider.java
@@ -1,0 +1,17 @@
+package com.remiaft.neteasewordscheck.cache;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.Optional;
+
+public interface CacheProvider extends Closeable {
+
+    void initialize();
+
+    Optional<CacheEntry> get(String content, Duration ttl);
+
+    void put(String content, String violation);
+
+    @Override
+    void close();
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/cache/ConnectionProvider.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/cache/ConnectionProvider.java
@@ -1,0 +1,8 @@
+package com.remiaft.neteasewordscheck.cache;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface ConnectionProvider {
+    Connection getConnection() throws SQLException;
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/cache/H2ConnectionProvider.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/cache/H2ConnectionProvider.java
@@ -1,0 +1,21 @@
+package com.remiaft.neteasewordscheck.cache;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Objects;
+
+public final class H2ConnectionProvider implements ConnectionProvider {
+    private final Path databaseFile;
+
+    public H2ConnectionProvider(Path databaseFile) {
+        this.databaseFile = Objects.requireNonNull(databaseFile, "databaseFile");
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        String url = "jdbc:h2:" + databaseFile.toAbsolutePath().toString() + ";MODE=MySQL;AUTO_SERVER=TRUE";
+        return DriverManager.getConnection(url, "sa", "");
+    }
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/cache/MySqlConnectionProvider.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/cache/MySqlConnectionProvider.java
@@ -1,0 +1,23 @@
+package com.remiaft.neteasewordscheck.cache;
+
+import com.remiaft.neteasewordscheck.config.MySqlSettings;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Objects;
+
+public final class MySqlConnectionProvider implements ConnectionProvider {
+    private final MySqlSettings settings;
+
+    public MySqlConnectionProvider(MySqlSettings settings) {
+        this.settings = Objects.requireNonNull(settings, "settings");
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        String url = String.format("jdbc:mysql://%s:%d/%s?useUnicode=true&characterEncoding=UTF-8&useSSL=%s",
+                settings.getHost(), settings.getPort(), settings.getDatabase(), settings.isUseSsl());
+        return DriverManager.getConnection(url, settings.getUsername(), settings.getPassword());
+    }
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/cache/SqlCacheProvider.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/cache/SqlCacheProvider.java
@@ -1,0 +1,108 @@
+package com.remiaft.neteasewordscheck.cache;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class SqlCacheProvider implements CacheProvider {
+    private static final String TABLE = "netease_words_cache";
+
+    private final ConnectionProvider connectionProvider;
+    private final Logger logger;
+
+    public SqlCacheProvider(ConnectionProvider connectionProvider, Logger logger) {
+        this.connectionProvider = connectionProvider;
+        this.logger = logger;
+    }
+
+    @Override
+    public void initialize() {
+        try (Connection connection = connectionProvider.getConnection();
+             PreparedStatement statement = connection.prepareStatement(
+                     "CREATE TABLE IF NOT EXISTS " + TABLE + " (" +
+                             "content VARCHAR(512) PRIMARY KEY," +
+                             "violation TEXT," +
+                             "checked_at TIMESTAMP NOT NULL" +
+                             ")")) {
+            statement.executeUpdate();
+        } catch (SQLException exception) {
+            logger.log(Level.SEVERE, "Failed to initialize SQL cache", exception);
+        }
+    }
+
+    @Override
+    public Optional<CacheEntry> get(String content, Duration ttl) {
+        if (content == null || content.isBlank()) {
+            return Optional.empty();
+        }
+        try (Connection connection = connectionProvider.getConnection();
+             PreparedStatement statement = connection.prepareStatement(
+                     "SELECT violation, checked_at FROM " + TABLE + " WHERE content = ?")) {
+            statement.setString(1, content);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (!rs.next()) {
+                    return Optional.empty();
+                }
+                Timestamp timestamp = rs.getTimestamp("checked_at");
+                if (timestamp == null) {
+                    return Optional.empty();
+                }
+                Instant checkedAt = timestamp.toInstant();
+                if (checkedAt.plus(ttl).isBefore(Instant.now())) {
+                    delete(content);
+                    return Optional.empty();
+                }
+                String violation = rs.getString("violation");
+                return Optional.of(new CacheEntry(content, violation, checkedAt));
+            }
+        } catch (SQLException exception) {
+            logger.log(Level.WARNING, "Failed to query cache", exception);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void put(String content, String violation) {
+        Instant now = Instant.now();
+        try (Connection connection = connectionProvider.getConnection()) {
+            deleteInternal(connection, content);
+            try (PreparedStatement insert = connection.prepareStatement(
+                    "INSERT INTO " + TABLE + " (content, violation, checked_at) VALUES (?, ?, ?)")) {
+                insert.setString(1, content);
+                insert.setString(2, violation);
+                insert.setTimestamp(3, Timestamp.from(now));
+                insert.executeUpdate();
+            }
+        } catch (SQLException exception) {
+            logger.log(Level.WARNING, "Failed to store cache entry", exception);
+        }
+    }
+
+    private void delete(String content) {
+        try (Connection connection = connectionProvider.getConnection()) {
+            deleteInternal(connection, content);
+        } catch (SQLException exception) {
+            logger.log(Level.FINE, "Failed to delete cache entry", exception);
+        }
+    }
+
+    private void deleteInternal(Connection connection, String content) throws SQLException {
+        try (PreparedStatement delete = connection.prepareStatement(
+                "DELETE FROM " + TABLE + " WHERE content = ?")) {
+            delete.setString(1, content);
+            delete.executeUpdate();
+        }
+    }
+
+    @Override
+    public void close() {
+        // Nothing to close; connections are provided per operation.
+    }
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/config/MySqlSettings.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/config/MySqlSettings.java
@@ -1,0 +1,45 @@
+package com.remiaft.neteasewordscheck.config;
+
+import java.util.Objects;
+
+public final class MySqlSettings {
+    private final String host;
+    private final int port;
+    private final String database;
+    private final String username;
+    private final String password;
+    private final boolean useSsl;
+
+    public MySqlSettings(String host, int port, String database, String username, String password, boolean useSsl) {
+        this.host = Objects.requireNonNull(host, "host");
+        this.port = port;
+        this.database = Objects.requireNonNull(database, "database");
+        this.username = Objects.requireNonNull(username, "username");
+        this.password = Objects.requireNonNull(password, "password");
+        this.useSsl = useSsl;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public boolean isUseSsl() {
+        return useSsl;
+    }
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/config/PluginConfiguration.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/config/PluginConfiguration.java
@@ -1,0 +1,93 @@
+package com.remiaft.neteasewordscheck.config;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Properties;
+
+public final class PluginConfiguration {
+
+    public enum CacheMode {
+        H2,
+        MYSQL;
+
+        public static CacheMode fromString(String value) {
+            if (value == null || value.isBlank()) {
+                return H2;
+            }
+            return CacheMode.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        }
+    }
+
+    private final CacheMode cacheMode;
+    private final Duration cacheTtl;
+    private final boolean blockOnViolation;
+    private final MySqlSettings mySqlSettings;
+    private final int workerThreads;
+
+    private PluginConfiguration(CacheMode cacheMode,
+                                Duration cacheTtl,
+                                boolean blockOnViolation,
+                                MySqlSettings mySqlSettings,
+                                int workerThreads) {
+        this.cacheMode = Objects.requireNonNull(cacheMode, "cacheMode");
+        this.cacheTtl = Objects.requireNonNull(cacheTtl, "cacheTtl");
+        this.blockOnViolation = blockOnViolation;
+        this.mySqlSettings = Objects.requireNonNull(mySqlSettings, "mySqlSettings");
+        this.workerThreads = workerThreads;
+    }
+
+    public static PluginConfiguration fromProperties(Properties properties) {
+        CacheMode mode = CacheMode.fromString(properties.getProperty("cache.mode", "H2"));
+        long ttlMinutes = parseLong(properties.getProperty("cache.ttl-minutes"), 60L);
+        boolean block = Boolean.parseBoolean(properties.getProperty("chat.block-on-violation", "true"));
+        int threads = (int) parseLong(properties.getProperty("worker-threads"), 4L);
+
+        MySqlSettings settings = new MySqlSettings(
+                properties.getProperty("mysql.host", "localhost"),
+                (int) parseLong(properties.getProperty("mysql.port"), 3306L),
+                properties.getProperty("mysql.database", "netease_words"),
+                properties.getProperty("mysql.username", "root"),
+                properties.getProperty("mysql.password", ""),
+                Boolean.parseBoolean(properties.getProperty("mysql.use-ssl", "false"))
+        );
+
+        return new PluginConfiguration(mode, Duration.ofMinutes(ttlMinutes), block, settings, Math.max(1, threads));
+    }
+
+    private static long parseLong(String value, long defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+
+    public static PluginConfiguration defaults() {
+        return new PluginConfiguration(CacheMode.H2, Duration.ofMinutes(60), true,
+                new MySqlSettings("localhost", 3306, "netease_words", "root", "", false), 4);
+    }
+
+    public CacheMode getCacheMode() {
+        return cacheMode;
+    }
+
+    public Duration getCacheTtl() {
+        return cacheTtl;
+    }
+
+    public boolean isBlockOnViolation() {
+        return blockOnViolation;
+    }
+
+    public MySqlSettings getMySqlSettings() {
+        return mySqlSettings;
+    }
+
+    public int getWorkerThreads() {
+        return workerThreads;
+    }
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/http/NeteaseApiClient.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/http/NeteaseApiClient.java
@@ -1,0 +1,56 @@
+package com.remiaft.neteasewordscheck.http;
+
+import org.json.JSONObject;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class NeteaseApiClient {
+    private static final URI API_ENDPOINT = URI.create("https://g79apigatewayobt.nie.netease.com/mc-server/check-words-sensitive");
+
+    private final HttpClient client;
+    private final Logger logger;
+
+    public NeteaseApiClient(Logger logger) {
+        this.logger = logger;
+        this.client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    public Optional<String> checkContent(String content) {
+        try {
+            JSONObject payload = new JSONObject();
+            payload.put("content", content);
+
+            HttpRequest request = HttpRequest.newBuilder(API_ENDPOINT)
+                    .timeout(Duration.ofSeconds(10))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(payload.toString(), StandardCharsets.UTF_8))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+
+            if (response.statusCode() != 200) {
+                logger.log(Level.WARNING, "Unexpected response code {0} from NetEase API", response.statusCode());
+                return Optional.empty();
+            }
+
+            JSONObject json = new JSONObject(response.body());
+            if (json.optInt("code", -1) == 0) {
+                return Optional.empty();
+            }
+            return Optional.ofNullable(json.optString("details", null));
+        } catch (Exception exception) {
+            logger.log(Level.WARNING, "Failed to contact NetEase API", exception);
+            return Optional.empty();
+        }
+    }
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/service/CheckResult.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/service/CheckResult.java
@@ -1,0 +1,30 @@
+package com.remiaft.neteasewordscheck.service;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public final class CheckResult {
+    private final boolean allowed;
+    private final String violationDetails;
+
+    private CheckResult(boolean allowed, String violationDetails) {
+        this.allowed = allowed;
+        this.violationDetails = violationDetails;
+    }
+
+    public static CheckResult allowed() {
+        return new CheckResult(true, null);
+    }
+
+    public static CheckResult denied(String violationDetails) {
+        return new CheckResult(false, Objects.requireNonNull(violationDetails, "violationDetails"));
+    }
+
+    public boolean isAllowed() {
+        return allowed;
+    }
+
+    public Optional<String> getViolationDetails() {
+        return Optional.ofNullable(violationDetails);
+    }
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/service/NeteaseWordsCheckCore.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/service/NeteaseWordsCheckCore.java
@@ -1,0 +1,52 @@
+package com.remiaft.neteasewordscheck.service;
+
+import com.remiaft.neteasewordscheck.cache.CacheProvider;
+import com.remiaft.neteasewordscheck.cache.H2ConnectionProvider;
+import com.remiaft.neteasewordscheck.cache.MySqlConnectionProvider;
+import com.remiaft.neteasewordscheck.cache.SqlCacheProvider;
+import com.remiaft.neteasewordscheck.config.PluginConfiguration;
+import com.remiaft.neteasewordscheck.http.NeteaseApiClient;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+
+public final class NeteaseWordsCheckCore implements AutoCloseable {
+    private final WordCheckService wordCheckService;
+
+    public NeteaseWordsCheckCore(Path dataFolder,
+                                 PluginConfiguration configuration,
+                                 Logger logger) throws IOException {
+        Files.createDirectories(dataFolder);
+        CacheProvider cacheProvider = createCacheProvider(dataFolder, configuration, logger);
+        cacheProvider.initialize();
+        this.wordCheckService = new WordCheckService(cacheProvider,
+                new NeteaseApiClient(logger),
+                configuration.getCacheTtl(),
+                configuration.getWorkerThreads(),
+                logger);
+    }
+
+    private CacheProvider createCacheProvider(Path dataFolder,
+                                               PluginConfiguration configuration,
+                                               Logger logger) {
+        switch (configuration.getCacheMode()) {
+            case MYSQL:
+                return new SqlCacheProvider(new MySqlConnectionProvider(configuration.getMySqlSettings()), logger);
+            case H2:
+            default:
+                Path databaseFile = dataFolder.resolve("netease_words");
+                return new SqlCacheProvider(new H2ConnectionProvider(databaseFile), logger);
+        }
+    }
+
+    public WordCheckService getWordCheckService() {
+        return wordCheckService;
+    }
+
+    @Override
+    public void close() {
+        wordCheckService.close();
+    }
+}

--- a/common/src/main/java/com/remiaft/neteasewordscheck/service/WordCheckService.java
+++ b/common/src/main/java/com/remiaft/neteasewordscheck/service/WordCheckService.java
@@ -1,0 +1,78 @@
+package com.remiaft.neteasewordscheck.service;
+
+import com.remiaft.neteasewordscheck.cache.CacheEntry;
+import com.remiaft.neteasewordscheck.cache.CacheProvider;
+import com.remiaft.neteasewordscheck.http.NeteaseApiClient;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.logging.Logger;
+
+public final class WordCheckService implements AutoCloseable {
+    private final CacheProvider cacheProvider;
+    private final NeteaseApiClient apiClient;
+    private final Duration cacheTtl;
+    private final ExecutorService executor;
+    private final Logger logger;
+
+    public WordCheckService(CacheProvider cacheProvider,
+                            NeteaseApiClient apiClient,
+                            Duration cacheTtl,
+                            int workerThreads,
+                            Logger logger) {
+        this.cacheProvider = cacheProvider;
+        this.apiClient = apiClient;
+        this.cacheTtl = cacheTtl;
+        this.logger = logger;
+        ThreadFactory factory = runnable -> {
+            Thread thread = new Thread(runnable, "netease-check-worker");
+            thread.setDaemon(true);
+            return thread;
+        };
+        this.executor = Executors.newFixedThreadPool(Math.max(1, workerThreads), factory);
+    }
+
+    public CompletableFuture<CheckResult> checkAsync(String content) {
+        String normalized = normalize(content);
+        if (normalized.isEmpty()) {
+            return CompletableFuture.completedFuture(CheckResult.allowed());
+        }
+        Optional<CacheEntry> cached = cacheProvider.get(normalized, cacheTtl);
+        if (cached.isPresent()) {
+            CacheEntry entry = cached.get();
+            if (entry.getViolation() == null || entry.getViolation().isBlank()) {
+                return CompletableFuture.completedFuture(CheckResult.allowed());
+            }
+            return CompletableFuture.completedFuture(CheckResult.denied(entry.getViolation()));
+        }
+        return CompletableFuture.supplyAsync(() -> {
+            Optional<String> violation = apiClient.checkContent(normalized);
+            violation.ifPresentOrElse(
+                    details -> cacheProvider.put(normalized, details),
+                    () -> cacheProvider.put(normalized, null)
+            );
+            return violation.map(CheckResult::denied).orElseGet(CheckResult::allowed);
+        }, executor);
+    }
+
+    private String normalize(String content) {
+        if (content == null) {
+            return "";
+        }
+        return content.trim();
+    }
+
+    @Override
+    public void close() {
+        executor.shutdownNow();
+        try {
+            cacheProvider.close();
+        } catch (Exception exception) {
+            logger.fine("Failed to close cache provider cleanly: " + exception.getMessage());
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.remiaft</groupId>
+    <artifactId>NeteaseWordsCheck</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>NeteaseWordsCheck</name>
+
+    <modules>
+        <module>common</module>
+        <module>bukkit</module>
+        <module>bungeecord</module>
+        <module>velocity</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <h2.version>2.2.224</h2.version>
+        <mysql.version>8.0.33</mysql.version>
+        <json.version>20230618</json.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>${mysql.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>${json.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>md-5-repo</id>
+            <url>https://repo.md-5.net/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+</project>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.remiaft</groupId>
+        <artifactId>NeteaseWordsCheck</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neteasewordscheck-velocity</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.remiaft</groupId>
+            <artifactId>neteasewordscheck-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>3.2.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.json</pattern>
+                                    <shadedPattern>com.remiaft.neteasewordscheck.shaded.json</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/velocity/src/main/java/com/remiaft/neteasewordscheck/velocity/NeteaseWordsCheckVelocityPlugin.java
+++ b/velocity/src/main/java/com/remiaft/neteasewordscheck/velocity/NeteaseWordsCheckVelocityPlugin.java
@@ -1,0 +1,178 @@
+package com.remiaft.neteasewordscheck.velocity;
+
+import com.google.inject.Inject;
+import com.remiaft.neteasewordscheck.config.PluginConfiguration;
+import com.remiaft.neteasewordscheck.service.CheckResult;
+import com.remiaft.neteasewordscheck.service.NeteaseWordsCheckCore;
+import com.remiaft.neteasewordscheck.service.WordCheckService;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
+import com.velocitypowered.api.event.player.PlayerChatEvent;
+import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.Component;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+@Plugin(id = "neteasewordscheck", name = "NeteaseWordsCheck", version = "1.0.0", authors = {"Angelhell"})
+public final class NeteaseWordsCheckVelocityPlugin {
+    private static final long CHECK_TIMEOUT_SECONDS = 5L;
+
+    private final ProxyServer server;
+    private final Logger logger;
+    private final Path dataDirectory;
+
+    private NeteaseWordsCheckCore core;
+    private PluginConfiguration configuration;
+
+    @Inject
+    public NeteaseWordsCheckVelocityPlugin(ProxyServer server, Logger logger, @com.velocitypowered.api.plugin.annotation.DataDirectory Path dataDirectory) {
+        this.server = server;
+        this.logger = logger;
+        this.dataDirectory = dataDirectory;
+    }
+
+    @Subscribe
+    public void onProxyInitialization(ProxyInitializeEvent event) {
+        try {
+            initialize();
+            server.getEventManager().register(this, this);
+            server.getCommandManager().register(
+                    server.getCommandManager().metaBuilder("neteasecheck").aliases("nwc").build(),
+                    new NeteaseCheckCommand()
+            );
+            logger.info("NeteaseWordsCheck Velocity module enabled.");
+        } catch (IOException exception) {
+            logger.error("Failed to initialize plugin", exception);
+        }
+    }
+
+    @Subscribe
+    public void onProxyShutdown(ProxyShutdownEvent event) {
+        if (core != null) {
+            core.close();
+            core = null;
+        }
+    }
+
+    @Subscribe
+    public void onChat(PlayerChatEvent event) {
+        if (core == null) {
+            return;
+        }
+        WordCheckService service = core.getWordCheckService();
+        String rawMessage = event.getMessage();
+        try {
+            CheckResult result = service.checkAsync(rawMessage).get(CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!result.isAllowed() && configuration.isBlockOnViolation()) {
+                event.setResult(PlayerChatEvent.ChatResult.denied());
+                event.getPlayer().sendMessage(Component.text("消息包含敏感词：" + result.getViolationDetails().orElse("未知违规内容")));
+            }
+        } catch (Exception exception) {
+            logger.warn("Failed to check chat message", exception);
+        }
+    }
+
+    private void initialize() throws IOException {
+        if (!Files.exists(dataDirectory)) {
+            Files.createDirectories(dataDirectory);
+        }
+        Path configFile = dataDirectory.resolve("config.properties");
+        if (!Files.exists(configFile)) {
+            try (InputStream in = getClass().getClassLoader().getResourceAsStream("config.properties")) {
+                if (in == null) {
+                    throw new IOException("Default configuration not found");
+                }
+                Files.copy(in, configFile);
+            }
+        }
+        Properties properties = new Properties();
+        try (InputStream in = Files.newInputStream(configFile)) {
+            properties.load(in);
+        }
+        configuration = PluginConfiguration.fromProperties(properties);
+        if (core != null) {
+            core.close();
+        }
+        Path dataPath = dataDirectory.resolve("data");
+        core = new NeteaseWordsCheckCore(dataPath, configuration, createJulLogger());
+    }
+
+    private java.util.logging.Logger createJulLogger() {
+        java.util.logging.Logger julLogger = java.util.logging.Logger.getLogger("NeteaseWordsCheck-Velocity");
+        julLogger.setUseParentHandlers(false);
+        for (Handler handler : julLogger.getHandlers()) {
+            julLogger.removeHandler(handler);
+        }
+        julLogger.addHandler(new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                if (!isLoggable(record)) {
+                    return;
+                }
+                Level level = record.getLevel();
+                String message = record.getMessage();
+                Throwable throwable = record.getThrown();
+                if (level.intValue() >= Level.SEVERE.intValue()) {
+                    logger.error(message, throwable);
+                } else if (level.intValue() >= Level.WARNING.intValue()) {
+                    logger.warn(message, throwable);
+                } else if (level.intValue() >= Level.INFO.intValue()) {
+                    logger.info(message, throwable);
+                } else {
+                    logger.debug(message, throwable);
+                }
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        });
+        julLogger.setLevel(Level.ALL);
+        return julLogger;
+    }
+
+    private final class NeteaseCheckCommand implements SimpleCommand {
+        @Override
+        public void execute(Invocation invocation) {
+            if (core == null) {
+                invocation.source().sendMessage(Component.text("插件尚未准备就绪."));
+                return;
+            }
+            String[] args = invocation.arguments();
+            if (args.length == 0) {
+                invocation.source().sendMessage(Component.text("用法: /neteasecheck <内容>"));
+                return;
+            }
+            String message = String.join(" ", args);
+            invocation.source().sendMessage(Component.text("正在检查消息，请稍候..."));
+            core.getWordCheckService().checkAsync(message).whenComplete((result, throwable) -> {
+                if (throwable != null) {
+                    logger.warn("Failed to check message", throwable);
+                    invocation.source().sendMessage(Component.text("检查失败，请查看后台日志。"));
+                    return;
+                }
+                if (result.isAllowed()) {
+                    invocation.source().sendMessage(Component.text("未检测到敏感词。"));
+                } else {
+                    invocation.source().sendMessage(Component.text("检测到敏感词：" + result.getViolationDetails().orElse("未知")));
+                }
+            });
+        }
+    }
+}

--- a/velocity/src/main/resources/config.properties
+++ b/velocity/src/main/resources/config.properties
@@ -1,0 +1,10 @@
+cache.mode=H2
+cache.ttl-minutes=60
+chat.block-on-violation=true
+mysql.host=localhost
+mysql.port=3306
+mysql.database=netease_words
+mysql.username=root
+mysql.password=
+mysql.use-ssl=false
+worker-threads=4

--- a/velocity/src/main/resources/velocity-plugin.json
+++ b/velocity/src/main/resources/velocity-plugin.json
@@ -1,0 +1,7 @@
+{
+  "id": "neteasewordscheck",
+  "name": "NeteaseWordsCheck",
+  "version": "${project.version}",
+  "authors": ["Angelhell"],
+  "main": "com.remiaft.neteasewordscheck.velocity.NeteaseWordsCheckVelocityPlugin"
+}


### PR DESCRIPTION
## Summary
- add a multi-module Maven build with shared common logic for caching NetEase checks and SQL storage backends
- implement Bukkit, BungeeCord, and Velocity plugins that block or report sensitive chat content and expose a `/neteasecheck` command
- provide default configuration files for local H2 caching with optional MySQL support

## Testing
- mvn -U package

------
https://chatgpt.com/codex/tasks/task_e_68e391cf4a2c832a9bee34114458d4ef